### PR TITLE
10 sec phase for faction soldiers added

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -15080,7 +15080,7 @@ messages:
 
    StartPhaseTimer()
    {
-      local i;
+      local i, iPhaseTime, oSoldierShield;
 
       // If phase time regen timer is active, delete it.
       if (ptPhaseRegenTimer <> $)
@@ -15090,9 +15090,17 @@ messages:
       }
 
       if ptPhaseTimer = $
-      {
-         ptPhaseTimer = CreateTimer(self,@PhaseTimerEnd,piRemainingPhaseTime);
+      { 
+         // NEW: If there is a soldier shield then we will introduce a short pen to reward PVP immediately.
+         iPhaseTime = piRemainingPhaseTime; // still use the time as the default
+         oSoldierShield = Send(self,@FindUsing,#class=&SoldierShield);       
+         if oSoldierShield <> $
+         {
+            iPhaseTime = 1000 * 10; // 10 seconds
+         }
 
+         ptPhaseTimer = CreateTimer(self,@PhaseTimerEnd,iPhaseTime);
+         
          // Stop any rescue attempts if the user phases out.
          if ptRescue <> $
          {


### PR DESCRIPTION
# Feature: Shorter phase timer (with reset) for faction soldiers in PVP

## The actual situation
In PVP you will get a reward if you a) kill someone or b) pen someone.

To pen someone means that you manage to hold the logoff ghost(s) of phased enemies for a couple of minutes until a specific timer has ended. Then you will get a reward in honor points and some loot.

This timer enables the user to bring another toon or friends to help, which leads to more and more people logging in and joining the fight.

A typical Guild vs Guild (GvG) combats usually starts by logging one of the enemies while building or doing tasks.

The phase spell and its timer effects PVP and PVE.

## The problem

The current system works like in a "the winner takes it all" manner because phasing someone earns you nothing.

Thus its a more effective tactic to bring more drivers and toons instead of getting better at the game by improving your playstyle like finding a new counter build.

More drivers are a rare resource so that doesnt scale for solo players or smaller guilds.

## Basic idea

Phasing someone in PVP should be rewarded to increase the player motivation. Thus even a solo player can gain a positive feeling by phasing someone from a larger guild and has no problem getting phased in return.

In contrast phasing someone while PVE should not be negatively effected because the current system works very well there and needs not to be changed.

## Possible solution

Soldiers of a faction should be impacted by a shorter phase timer to enable trigger the reward system earlier.

## Implementation

The following files needed to be modified to implement this feature.

**player.kod**

This file handles the phase technically by providing corresponding methods to create, refresh or delete timers.
To implement the behaviour wanted it is necessary to change the `StartPhaseTimer` method.

Instead of using the same phase time for each user on creation like this:

    ptPhaseTimer = CreateTimer(self,@PhaseTimerEnd,piRemainingPhaseTime);

This section could be change to:

    // NEW: If there is a soldier shield then we will introduce a short pen to reward PVP immediately.

    iPhaseTime = piRemainingPhaseTime; // still use the original time as the default
    
    oSoldierShield = Send(self,@FindUsing,#class=&SoldierShield);       
    if oSoldierShield <> $
    {
        iPhaseTime = 1000 * 10; // 10 seconds
    }

    ptPhaseTimer = CreateTimer(self,@PhaseTimerEnd,iPhaseTime);
