### PR TITLE
instant pen introduced

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -578,9 +578,6 @@ properties:
    // List of user objects this user cannot receive communications from.
    plForcedIgnore = $
 
-   // Instant pen related stuff
-   piIsInstantPenActive = 0
-
 messages:
 
    Constructor(name = $,icon = $)
@@ -1341,11 +1338,12 @@ messages:
       iHonorEach = Send(SETTINGS_OBJECT,@GetHonorLossPen);
       iLostTotal = 0;
 
-      // Instant pen is awarded 25%.
-      if piIsInstantPenActive = 1
+      // Instant pen is awarded 25%
+      if Send(SETTINGS_OBJECT,@IsInstantPenActive) = 1
          AND iHonorEach > 0
       {
          iHonorEach = iHonorEach * 25 / 100;
+         Debug("Instant pen: ",self," loses ",iHonorEach," honor.");
       }
 
       // Find out how many people attacked us recently. Don't count ourselves.
@@ -12465,40 +12463,32 @@ messages:
       return;
    }
 
-   DoInstantPen(who = $)
+   DoInstantPen()
    "Provides an instant penalty aka reward for phasing someone."
    {
-      local iCol, iFineRow, iFineCol, iRow, oHealWand, oRoom;
+      local oHealWand, oRoom;
 
-      if who = $
-      {
-         return;
-      }
       // Instant pen should only apply on players which have attacked other players recently.
-      if IsClass(who,&Player) AND (NOT Send(who,@CanHelpPlayer)
-            OR Send(who,@PlayerIsImmortal))
+      if IsClass(self,&Player) AND (NOT Send(self,@CanHelpPlayer)
+            OR Send(self,@PlayerIsImmortal))
       {
          // Needed in the honour point calculation.
-         piIsInstantPenActive = 1;
+         Send(SETTINGS_OBJECT,@SetInstantPenActive);
          // Find the first heal wand in the inventory and drop it if found.
          oHealWand = GetListElemByClass(plPassive,&HealWand);
          if oHealWand <> $
          {
             // Get current room and position for the drop.
-            oRoom = Send(who,@GetOwner);
-            iRow = Send(who,@GetRow);
-            iCol = Send(who,@GetCol);
-            iFineRow = Send(who,@GetFineRow);
-            iFineCol = Send(who,@GetFineCol);
+            oRoom = Send(self,@GetOwner);
             // Drop the item.       
             Send(oRoom,@NewHold,
                #what=oHealWand,
-               #new_row=iRow,#new_col=iCol,
-               #fine_row=iFineRow,#fine_col=iFineCol);
+               #new_row=piRow,#new_col=piCol,
+               #fine_row=piFine_row,#fine_col=piFine_col);
          }
          // Trigger honour points award
-         Send(who,@PenaltyLoseHonor,#where=who);
-         piIsInstantPenActive = 0;
+         Send(self,@PenaltyLoseHonor,#where=self);
+         Send(SETTINGS_OBJECT,@SetInstantPenInactive);
       }
       return;
    }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1339,7 +1339,7 @@ messages:
       iLostTotal = 0;
 
       // Instant pen is awarded 25%
-      if Send(SETTINGS_OBJECT,@IsInstantPenActive) = 1
+      if Send(SETTINGS_OBJECT,@IsInstantPenActive)
          AND iHonorEach > 0
       {
          iHonorEach = iHonorEach * 25 / 100;
@@ -12469,8 +12469,8 @@ messages:
       local oHealWand, oRoom;
 
       // Instant pen should only apply on players which have attacked other players recently.
-      if IsClass(self,&Player) AND (NOT Send(self,@CanHelpPlayer)
-            OR Send(self,@PlayerIsImmortal))
+      if IsClass(self,&Player)
+         AND NOT (Send(self,@CanHelpPlayer) OR Send(self,@PlayerIsImmortal))
       {
          // Needed in the honour point calculation.
          Send(SETTINGS_OBJECT,@SetInstantPenActive);

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -578,6 +578,9 @@ properties:
    // List of user objects this user cannot receive communications from.
    plForcedIgnore = $
 
+   // Instant pen related stuff
+   piIsInstantPenActive = 0
+
 messages:
 
    Constructor(name = $,icon = $)
@@ -1337,6 +1340,13 @@ messages:
       iNumHurters = 0;
       iHonorEach = Send(SETTINGS_OBJECT,@GetHonorLossPen);
       iLostTotal = 0;
+
+      // Instant pen is awarded 25%.
+      if piIsInstantPenActive = 1
+         AND iHonorEach > 0
+      {
+         iHonorEach = iHonorEach * 25 / 100;
+      }
 
       // Find out how many people attacked us recently. Don't count ourselves.
       foreach i in plHurtMeRecently
@@ -12452,6 +12462,44 @@ messages:
    SetLastServerTeleport()
    {
       piLastServerTeleport = GetTickCount();
+      return;
+   }
+
+   DoInstantPen(who = $)
+   "Provides an instant penalty aka reward for phasing someone."
+   {
+      local iCol, iFineRow, iFineCol, iRow, oHealWand, oRoom;
+
+      if who = $
+      {
+         return;
+      }
+      // Instant pen should only apply on players which have attacked other players recently.
+      if IsClass(who,&Player) AND (NOT Send(who,@CanHelpPlayer)
+            OR Send(who,@PlayerIsImmortal))
+      {
+         // Needed in the honour point calculation.
+         piIsInstantPenActive = 1;
+         // Find the first heal wand in the inventory and drop it if found.
+         oHealWand = GetListElemByClass(plPassive,&HealWand);
+         if oHealWand <> $
+         {
+            // Get current room and position for the drop.
+            oRoom = Send(who,@GetOwner);
+            iRow = Send(who,@GetRow);
+            iCol = Send(who,@GetCol);
+            iFineRow = Send(who,@GetFineRow);
+            iFineCol = Send(who,@GetFineCol);
+            // Drop the item.       
+            Send(oRoom,@NewHold,
+               #what=oHealWand,
+               #new_row=iRow,#new_col=iCol,
+               #fine_row=iFineRow,#fine_col=iFineCol);
+         }
+         // Trigger honour points award
+         Send(who,@PenaltyLoseHonor,#where=who);
+         piIsInstantPenActive = 0;
+      }
       return;
    }
 

--- a/kod/object/passive/spell/utility/phase.kod
+++ b/kod/object/passive/spell/utility/phase.kod
@@ -229,7 +229,7 @@ messages:
                   #iHealth=Send(who,@GetHealth),
                   #iMaxHealth=Send(who,@GetMaxHealth));
          }
-         Send(who,@DoInstantPen,#who=who);
+         Send(who,@DoInstantPen);
          // Post this because FreezeAllEnchantments checks for phase applied
          Post(who,@StartEnchantment,#what=self);
          Post(who,@StartPhaseTimer);

--- a/kod/object/passive/spell/utility/phase.kod
+++ b/kod/object/passive/spell/utility/phase.kod
@@ -229,6 +229,7 @@ messages:
                   #iHealth=Send(who,@GetHealth),
                   #iMaxHealth=Send(who,@GetMaxHealth));
          }
+         Send(who,@DoInstantPen,#who=who);
          // Post this because FreezeAllEnchantments checks for phase applied
          Post(who,@StartEnchantment,#what=self);
          Post(who,@StartPhaseTimer);

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -404,6 +404,9 @@ properties:
    // Are fizzles disabled?
    pbNoFizzles = FALSE
 
+   // Instant pen related stuff
+   piIsInstantPenActive = 0
+
 messages:
 
    Constructor()
@@ -1013,6 +1016,23 @@ messages:
    NoFizzles()
    {
       return pbNoFizzles;
+   }
+
+   IsInstantPenActive()
+   {
+      return piIsInstantPenActive;
+   }
+
+   SetInstantPenActive()
+   {
+      piIsInstantPenActive = 1;
+      return;
+   }
+
+   SetInstantPenInactive()
+   {
+      piIsInstantPenActive = 0;
+      return;
    }
 
 end


### PR DESCRIPTION
# Feature: Instant pen for PVP combatants

## The actual situation
In PVP you will get a reward if you a) kill someone or b) pen someone.

To pen someone means that you manage to hold the logoff ghost(s) of phased enemies for a couple of minutes until a specific timer has ended. Then you will get a reward in honor points and some loot.

This timer enables the user to bring another toon or friends to help, which leads to more and more people logging in and joining the fight.

A typical Guild vs Guild (GvG) combats usually starts by logging one of the enemies while building or doing tasks.

The phase spell and its timer effects PVP and PVE.

## The problem

The current system works like in a "the winner takes it all" manner because phasing someone earns you nothing.

Thus its a more effective tactic to bring more drivers and toons instead of getting better at the game by improving your playstyle like finding a new counter build.

More drivers are a rare resource so that doesnt scale for solo players or smaller guilds.

## Basic idea

Phasing someone in PVP should be rewarded to increase the player motivation. Thus even a solo player can gain a positive feeling by phasing someone from a larger guild and has no problem getting phased in return.

In contrast phasing someone while PVE should not be negatively effected because the current system works very well there and needs not to be changed.

## Possible solution

1. To phase someone in PVP should be rewarded directly to promote PvP by dropping PVP-valuable items like heal wands and a small amount of honor points (25%).
2. The phase delay should be increased slightly to make fast in/out phases and heal wand more difficult to use.

## Implementation

The following files needed to be modified to implement this feature.

**settings.kod**

This file provides general settings.

We need to at a property `piIsInstantPenActive` there to distinguish between a 25% instant pen honor loss and the classical one.

In addition we need to add corresponding message handlers `IsInstantPenActive`, `SetInstantPenActive` and `SetInstantPenInactive`.

**user.kod**

This file provides user related stuff like dropping items and handling the honor points.

We need add a new message handler named `DoInstantPen` which could be called via `Post` or `Send` later.

This handler ensures that the instant pen only triggers if the player phases and has attacked others players recently.

It searches the inventory for a heal wand and drops it to the ground.

Finally the player loses 25% of the usual honor points.

**phase.kod**

This file handles the phase spell in general by setting the **phase delay** via the property `piPhaseDelay = 3000` (was 1500 before) 

The message handler `DoSpellEffects` is doing the main work here and there we need to add a `Send(who,@DoInstantPen);` to trigger the instant pen implementation.
