### PR TITLE
chalice vanishes by offering to an NPC fixed

### DIFF
--- a/kod/object/item/passitem/chalice.kod
+++ b/kod/object/item/passitem/chalice.kod
@@ -94,6 +94,7 @@ messages:
 
          if oOtherChalice <> $
             AND NOT (IsClass(what,&DM) AND Send(what,@PlayerIsImmortal))
+            AND NOT (IsClass(what,&NonPlayerCharacter))
          {
             Send(what,@MsgSendUser,#message_rsc=chalice_combine);
             Send(oOtherChalice,@SetHits,#number=Send(oOtherChalice,@GetHits) + piHits);


### PR DESCRIPTION
Actually if you accidentally offer a Chalice to an NPC it displayes the "combine" message "You pour the water from one Chalice into the other" but also deletes it from your inventory.

This fix prevents that by ignoring NPCs in the "combine" logic.