### PR TITLE
chalice can not be given to an NPC

### DIFF
--- a/kod/object/item/passitem/chalice.kod
+++ b/kod/object/item/passitem/chalice.kod
@@ -54,6 +54,12 @@ properties:
 
 messages:
 
+   CanBeGivenToNPC()
+   "NPCs will refuse to take this item if offered to them."
+   {
+      return FALSE;
+   }
+
    ReqNewOwner(what=$)
    {
       if poOwner = Send(SYS,@FindRoomByNum,#num=RID_CAVE2)


### PR DESCRIPTION
Actually a player is able to offer a Chalice to an NPC which vanishes out of the inventory.