### PR TITLE
island monster level increase

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/avar.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/avar.kod
@@ -68,7 +68,7 @@ classvars:
    viAttack_type = ATK_TYPE_BLUDGEON
    viSpeed = SPEED_AVERAGE
    viDefault_behavior = AI_FIGHT_AGGRESSIVE
-   viLevel = 120
+   viLevel = 130
    viDifficulty = 7
    viVisionDistance = 16
 

--- a/kod/object/active/holder/nomoveon/battler/monster/dfly.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dfly.kod
@@ -70,7 +70,7 @@ classvars:
 
    viSpeed = SPEED_AVERAGE
    viAttack_type = ATK_TYPE_PIERCE
-   viLevel = 120
+   viLevel = 130
    viDifficulty = 6
    viMeleeRange = 0
    viFireRange = 192

--- a/kod/object/active/holder/nomoveon/battler/monster/factions/princess.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/factions/princess.kod
@@ -136,7 +136,7 @@ messages:
    {
       plFor_Sale = [$,
                     $,
-                    [ SID_CONCILIATION] ];
+                    [ SID_CONCILIATION], [SID_LULLABY] ];
 
       return;
    }

--- a/kod/object/passive/spell/radiusench/jala/manaconv.kod
+++ b/kod/object/passive/spell/radiusench/jala/manaconv.kod
@@ -64,6 +64,7 @@ classvars:
    viSchool = SS_JALA
    viSpell_level = 5
    viMeditate_ratio = 75
+   viBaseRange = 5 * FINENESS
 
    viAffectsEnemies = TRUE
 
@@ -83,14 +84,14 @@ messages:
 
    PeriodicEffect(who=$,state=$)
    {
-      local oCaster, iManaGain;
+      local oCaster, iManaGain, iSpellPower;
 
       oCaster = First(state);
 
       if (IsClass(who,&Player)
          AND NOT (who = oCaster))
       {
-         iManaGain = Send(who,@LoseMana,#amount=1);
+         iManaGain = Send(who,@LoseMana,#amount=(iSpellPower/40+1));
 
          if (iManaGain > 0)
          {

--- a/kod/object/passive/spell/radiusench/jala/manaconv.kod
+++ b/kod/object/passive/spell/radiusench/jala/manaconv.kod
@@ -87,6 +87,8 @@ messages:
       local oCaster, iManaGain, iSpellPower;
 
       oCaster = First(state);
+      
+      iSpellPower = Send(self,@GetSpellPower,#who=who);
 
       if (IsClass(who,&Player)
          AND NOT (who = oCaster))


### PR DESCRIPTION
To increase the range of places to level to 130 hit points outside of Brax.